### PR TITLE
Fix news order

### DIFF
--- a/backend/src/NewsPortal.Backend.Application/Item/ItemService.cs
+++ b/backend/src/NewsPortal.Backend.Application/Item/ItemService.cs
@@ -28,9 +28,8 @@ internal class ItemService : IItemService
         //  Get new story ids
         var newStoriesResponse = await _hackerNewsClient.GetNewStories();
         
-        //  Order and page ids
+        //  Apply pagination
         var newStories = newStoriesResponse.Data!
-            .OrderByDescending(x => x)
             .Skip((paginationFilter.PageNumber - 1) * paginationFilter.PageSize)
             .Take(paginationFilter.PageSize)
             .ToList();
@@ -62,6 +61,9 @@ internal class ItemService : IItemService
             //  Make resource thread safe
             lock (items) if (story != null) items.Add(story);
         });
+
+        //  Order news list
+        items = items.OrderByDescending(x => x.Id).ToList();
         
         return new ValueTuple<List<ItemDto>, int>(items, newStoriesResponse.Data!.Count);
     }


### PR DESCRIPTION
The HackerNews API returns the news in descending order (from newest to oldest), so there's no need to order the elements after hitting the get all stories endpoint.

Since the GetById is being executed in parallel, the news where being added to the result list disordered, so before returning the response is necessary to do and OrderByDescending. 